### PR TITLE
Route display of nodes to the appropriate controller

### DIFF
--- a/idc_ui_module.services.yml
+++ b/idc_ui_module.services.yml
@@ -1,0 +1,5 @@
+services:
+  mymodule.route_subscriber:
+    class: Drupal\idc_ui_module\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/src/Controller/NodeDisplayController.php
+++ b/src/Controller/NodeDisplayController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\idc_ui_module\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\node\Controller\NodeViewController;
+use Drupal\idc_ui_module\Controller\CollectionsController;
+
+class NodeDisplayController extends NodeViewController {
+
+  public function view(EntityInterface $node, $view_mode = 'full', $langcode = NULL) {
+    if (\Drupal::currentUser()->isAuthenticated()) {
+      return parent::view($node, $view_mode, $langcode);
+    } else {
+      $node_type = $node->get('type')->getString();
+
+      if ($node_type == 'collection_object') {
+        return CollectionsController::collection($node);
+      } elseif ($node_type == 'islandora_object') {
+        return CollectionsController::item($node);
+      } else {
+        return parent::view($node, $view_mode, $langcode);
+      }
+    }
+  }
+}

--- a/src/Controller/NodeDisplayController.php
+++ b/src/Controller/NodeDisplayController.php
@@ -11,18 +11,14 @@ use Drupal\idc_ui_module\Controller\CollectionsController;
 class NodeDisplayController extends NodeViewController {
 
   public function view(EntityInterface $node, $view_mode = 'full', $langcode = NULL) {
-    if (\Drupal::currentUser()->isAuthenticated()) {
-      return parent::view($node, $view_mode, $langcode);
-    } else {
-      $node_type = $node->get('type')->getString();
+    $node_type = $node->get('type')->getString();
 
-      if ($node_type == 'collection_object') {
-        return CollectionsController::collection($node);
-      } elseif ($node_type == 'islandora_object') {
-        return CollectionsController::item($node);
-      } else {
-        return parent::view($node, $view_mode, $langcode);
-      }
+    if ($node_type == 'collection_object') {
+      return CollectionsController::collection($node);
+    } elseif ($node_type == 'islandora_object') {
+      return CollectionsController::item($node);
+    } else {
+      return parent::view($node, $view_mode, $langcode);
     }
   }
 }

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\idc_ui_module\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRoutes(RouteCollection $collection) {
+
+    // Alter the canonical node route to our custom route
+    if ($route = $collection->get('entity.node.canonical')) {
+      $route->setDefault('_controller', '\Drupal\idc_ui_module\Controller\NodeDisplayController::view');
+    }
+  }
+}


### PR DESCRIPTION
- this uses a routing scheduler to run the rendering of a node through a display controller
- the display controller will render the default node view or the custom node views depending on node type
- the actual URI will remain unchanged as `node/{node}`.