### PR TITLE
clean up routes and controllers

### DIFF
--- a/idc_ui_module.routing.yml
+++ b/idc_ui_module.routing.yml
@@ -4,23 +4,4 @@ idc-ui-module.collections:
     _controller: '\Drupal\idc_ui_module\Controller\CollectionsController::collections'
   requirements:
     _permission: 'access content'
-idc-ui-module.collection:
-  path: 'collections/{collection}'
-  defaults:
-    _controller: '\Drupal\idc_ui_module\Controller\CollectionsController::collection'
-  options:
-    parameters:
-      collection:
-        type: entity:node
-  requirements:
-    _permission: 'access content'
-idc-ui-module.item:
-  path: 'items/{item}'
-  defaults:
-    _controller: '\Drupal\idc_ui_module\Controller\CollectionsController::item'
-  options:
-    parameters:
-      item:
-        type: entity:node
-  requirements:
-    _permission: 'access content'
+

--- a/src/Controller/CollectionsController.php
+++ b/src/Controller/CollectionsController.php
@@ -42,7 +42,7 @@ class CollectionsController extends ControllerBase {
         $image_display_url = file_create_url($image_url);
       }
 
-      $obj= (object) ['url' => $image_display_url, 'collection' => $collection];
+      $obj= (object) ['url' => $image_display_url, 'title' => $collection->get('title')->getString(), 'id' => $collection->id()];
 
       array_push($featured_collections_array, $obj);
     }
@@ -92,7 +92,7 @@ class CollectionsController extends ControllerBase {
         $image_display_url = file_create_url($image_url);
       }
 
-      $obj= (object) ['url' => $image_display_url, 'item' => $item];
+      $obj= (object) ['url' => $image_display_url, 'title' => $item->get('title')->getString(), 'id' => $item->id()];
 
       array_push($featured_items_array, $obj);
     }

--- a/templates/page--collection.html.twig
+++ b/templates/page--collection.html.twig
@@ -15,7 +15,7 @@
         <div class="flex overflow-x-scroll overflow-y-hidden items-center justify-start">
           {% if featured_items|length > 0 %}
             {% for item in featured_items %}
-              <a href={{ "/items/#{item.item.id}" }} class="flex-col mx-4 mb-4 w-64 h-64 shadow-md bg-white">
+              <a href={{ "/node/#{item.id}" }} class="flex-col mx-4 mb-4 w-64 h-64 shadow-md bg-white">
                 <div class="flex h-48 w-64 bg-gray-200 items-center justify-center">
                   {% if item.url %}
                     <img src={{item.url}} class="object-contain h-48 w-full" alt="featured item image" />
@@ -27,7 +27,7 @@
                 </div>
                 <div class="h-16 py-4 px-2 text-center">
                   <h3 class="text-sm md:text-lg font-bold">
-                    {{item.item.title.value}}
+                    {{item.title}}
                   </h3>
                 </div>
               </a>

--- a/templates/page--collections.html.twig
+++ b/templates/page--collections.html.twig
@@ -9,7 +9,7 @@
       <div class="flex overflow-x-scroll overflow-y-hidden items-center justify-start">
         {% if featured_collections|length > 0 %}
           {% for collection in featured_collections %}
-            <a href={{ "/collections/#{collection.collection.id}" }} class="flex-col mx-4 mb-4 w-64 h-64 shadow-md bg-white">
+            <a href={{ "/node/#{collection.id}" }} class="flex-col mx-4 mb-4 w-64 h-64 shadow-md bg-white">
               <div class="flex h-48 w-64 bg-gray-200 items-center justify-center">
                 {% if collection.url %}
                   <img src={{collection.url}} class="object-contain h-48 w-full" alt="featured collection image" />
@@ -21,7 +21,7 @@
               </div>
               <div class="h-16 py-4 px-2 text-center">
                 <h3 class="text-sm md:text-lg font-bold">
-                  {{collection.collection.title.value}}
+                  {{collection.title}}
                 </h3>
               </div>
             </a>


### PR DESCRIPTION
- removes custom routes for collection and item
- updates links between pages to use default node route
- now that we know how to access props off a drupal obj, do that and stop passing the whole object into the template