### PR TITLE
Explicitly disable caching for collections page

### DIFF
--- a/src/Controller/CollectionsController.php
+++ b/src/Controller/CollectionsController.php
@@ -50,6 +50,9 @@ class CollectionsController extends ControllerBase {
     return [
       '#theme' => 'page--collections',
       '#featured_collections' => $featured_collections_array,
+      '#cache' => [
+        'max-age'=> 0
+      ]
     ];
   }
 


### PR DESCRIPTION
This seems to address the concern about the Featured Items not responding to data changes (https://github.com/jhu-idc/idc-isle-dc/pull/80#issuecomment-779293283).

Not sure if there is a more granular way to disable caching for only the featured items check, or if it's necessary to disable caching for the entire page