### PR TITLE
Enable advanced search

### DIFF
--- a/idc_ui_module.module
+++ b/idc_ui_module.module
@@ -34,6 +34,9 @@ function idc_ui_module_theme($existing, $type, $theme, $path) {
     ],
     'idc_search_template' => [
       'variables' => []
+    ],
+    'page--advanced-search' => [
+      'variables' => []
     ]
   ];
 }

--- a/idc_ui_module.routing.yml
+++ b/idc_ui_module.routing.yml
@@ -2,6 +2,7 @@ idc-ui-module.collections:
   path: 'collections'
   defaults:
     _controller: '\Drupal\idc_ui_module\Controller\CollectionsController::collections'
+    _title: 'All collections'
   requirements:
     _permission: 'access content'
 
@@ -9,5 +10,14 @@ idc-ui-module.search:
   path: 'search'
   defaults:
     _controller: '\Drupal\idc_ui_module\Controller\SearchController::searchPage'
+    _title: 'Search'
+  requirements:
+    _permission: 'access content'
+
+idc-ui-module.advanced-search:
+  path: 'advanced-search'
+  defaults:
+    _controller: '\Drupal\idc_ui_module\Controller\SearchController::advancedSearch'
+    _title: 'Advanced Search'
   requirements:
     _permission: 'access content'

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -12,4 +12,10 @@ class SearchController extends ControllerBase {
     ];
   }
 
+  public function advancedSearch() {
+    return [
+      '#theme' => 'page--advanced-search'
+    ];
+  }
+
 }

--- a/templates/idc-search-template.html.twig
+++ b/templates/idc-search-template.html.twig
@@ -22,7 +22,7 @@
           class="inline-flex items-center px-3 py-2 h-10 border border-transparent text-sm leading-4 font-medium text-white bg-blue-heritage cursor-pointer hover:bg-gray-200 hover:text-blue-heritage" />
       </div>
       {# Hide advanced search link because it's not implemented yet #}
-      <a href="/advanced-search" class="text-blue-heritage hidden">Advanced Search</a>
+      <a href="/advanced-search" class="text-blue-heritage">Advanced Search</a>
     </div>
   </form>
 </div>

--- a/templates/page--advanced-search.html.twig
+++ b/templates/page--advanced-search.html.twig
@@ -1,3 +1,19 @@
+{# <div class="container mx-auto p-4">
+  <div class="card">
+    <div id="page-title" class="pb-4 mb-4 border-b">
+      <h1 class="text-3xl">Advanced Search</h1>
+    </div>
+    <div id="idc-advanced-search"></div>
+  </div>
+</div> #}
 <div class="p-4">
-  <div id="idc-advanced-search"></div>
+  <div
+    id="idc-search"
+    data-type="none"
+    data-title=""
+    data-search-placeholder="Search ..."
+    data-pagination-label="items"
+    data-enable-advanced-search="true"
+  ></div>
 </div>
+

--- a/templates/page--advanced-search.html.twig
+++ b/templates/page--advanced-search.html.twig
@@ -1,0 +1,3 @@
+<div class="p-4">
+  <div id="idc-advanced-search"></div>
+</div>

--- a/templates/page--search.html.twig
+++ b/templates/page--search.html.twig
@@ -5,6 +5,5 @@
     data-title=""
     data-search-placeholder="Search ..."
     data-pagination-label="items"
-    data-enable-advanced-search="true"
   ></div>
 </div>

--- a/templates/page--search.html.twig
+++ b/templates/page--search.html.twig
@@ -5,5 +5,6 @@
     data-title=""
     data-search-placeholder="Search ..."
     data-pagination-label="items"
+    data-enable-advanced-search="true"
   ></div>
 </div>


### PR DESCRIPTION
* Adds and `/advanced-search` route
  Would like to discuss whether this route is even necessary. I.E. given the UI being developed, should we simply make advanced search be included in the `/search` route, and potentially in the other search interfaces?
* Add some titles to our custom pages, which are displayed in browser tabs