### PR TITLE
Disable caching on collection details pages

### DIFF
--- a/src/Controller/CollectionsController.php
+++ b/src/Controller/CollectionsController.php
@@ -125,7 +125,10 @@ class CollectionsController extends ControllerBase {
       '#collection' => $collection,
       '#featured_items' => $featured_items_array,
       '#primary_description' => $primary_description,
-      '#citable_url' => $citable_url
+      '#citable_url' => $citable_url,
+      '#cache' => [
+        'max-age'=> 0
+      ]
     ];
   }
 


### PR DESCRIPTION
Resolves https://github.com/jhu-idc/iDC-general/issues/348

Disable caching seems to be the simplest way to get the expected behavior. Note that collection details uses Drupal's default node route, so this module doesn't have an entry defined for it in the `routing.yml` config, thus caching is disabled in the controller.