### PR TITLE
Add token to fetch collection contact for a repo item

### DIFF
--- a/idc_ui_module.tokens.inc
+++ b/idc_ui_module.tokens.inc
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Implements hook_token_info().
+ */
+function idc_ui_module_token_info() {
+  $info = [];
+  $info['types']['idc_token_group'] = array(
+    'name' => t('IDC tokens'),
+    'description' => t('IDC custom tokens'),
+  );
+  $info['tokens']['idc_token_group']['repo_item_parent'] = array(
+    'name' => t('Repository item parent collection'),
+    'description' => t('Get the parent collection of the repository item on this page.'),
+  );
+
+  return $info;
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function idc_ui_module_tokens($type, $tokens, array $data, array $options, \Drupal\Core\Render\BubbleableMetadata $bubbleable_metadata) {
+  $replacements = [];
+
+  if ($type == 'idc_token_group') {
+    foreach ($tokens as $name => $original) {
+      switch ($name) {
+        case 'repo_item_parent':
+          $parents = \Drupal::routeMatch()
+            ->getParameter('node')
+            ->get('field_member_of')
+            ->referencedEntities();
+
+          $replacements[$original] = $parents[0]->id();
+          break;
+      }
+    }
+  }
+
+  return $replacements;
+}


### PR DESCRIPTION
Drupal tokens allow for dynamic string replacements at runtime. This token is designed to be used on repository item pages and will return the node ID of the (first) parent collection from `field_member_of`. This will allow a contact form to reference the collection and automagically send an email to the collection contact, once configured properly.

Prerequisite for https://github.com/jhu-idc/iDC-general/issues/107 - at least the item email form part.