### PR TITLE
Fix immediate crash when repo item has no parent collection

### DIFF
--- a/idc_ui_module.tokens.inc
+++ b/idc_ui_module.tokens.inc
@@ -32,7 +32,10 @@ function idc_ui_module_tokens($type, $tokens, array $data, array $options, \Drup
             ->get('field_member_of')
             ->referencedEntities();
 
-          $replacements[$original] = $parents[0]->id();
+          if (!empty($parents) && count($parents) > 0) {
+            $replacements[$original] = array_values($parents)[0]->id();
+          }
+
           break;
       }
     }


### PR DESCRIPTION
High priority, as it actively breaks the Item Details page.

We may want to augment this later for UX. For example. if the repository item either has no parent collection or its parent collection has no contact information, we should hide the "Ask admin" button to prevent the user from attempting to use the contact form.