### PR TITLE
Autofill repo item title in contact form subject

### DIFF
--- a/idc_ui_module.module
+++ b/idc_ui_module.module
@@ -150,3 +150,15 @@ function idc_ui_module_views_post_render(ViewExecutable $view, &$output, CachePl
     $output['#cache']['tags'][] = 'node_list';
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter()
+ * Modify Repository Item Contact Form to the item's title to the subject
+ */
+function idc_ui_module_form_contact_message_repository_item_contact_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  $node = \Drupal::routeMatch()->getParameter('node');
+
+  if (!empty($node)) {
+    $form['subject']['widget'][0]['value']['#default_value'] = $node->getTitle() . ' (' . $node->id() . ')';
+  }
+}


### PR DESCRIPTION
Thinking back, this might have been a better approach for autofilling other fields on the collection and repo item contact forms - instead of using several other modules