### PR TITLE
Prevent collections page from being cached

### DIFF
--- a/idc_ui_module.routing.yml
+++ b/idc_ui_module.routing.yml
@@ -3,6 +3,8 @@ idc-ui-module.collections:
   defaults:
     _controller: '\Drupal\idc_ui_module\Controller\CollectionsController::collections'
     _title: 'All collections'
+  options:
+    no_cache: TRUE
   requirements:
     _permission: 'access content'
 


### PR DESCRIPTION
Related: https://github.com/jhu-idc/iDC-general/issues/433

This should allow anonymous users to see Featured Items correctly after the data has been updated. The issue is that the entire page was being cached for anonymous users, bypassing any template logic and preventing anonymous users from seeing updated data. There may be a more fine grained way of fixing this, but this seems to be the easiest fix