### PR TITLE
Squash duplicate thumbnails for /collections

### DIFF
--- a/src/Controller/CollectionsController.php
+++ b/src/Controller/CollectionsController.php
@@ -43,8 +43,10 @@ class CollectionsController extends ControllerBase {
       $thumbnail_id = array_values($media)[0]->thumbnail->target_id;
 
       $thumbnail = \Drupal::entityTypeManager()
-      ->getStorage('file')
-      ->load($thumbnail_id);
+        ->getStorage('file')
+        ->load($thumbnail_id);
+
+      $image_display_url = '';
 
       if ($thumbnail) {
         $image_url = $thumbnail->getFileUri();


### PR DESCRIPTION
The previous fix for duplicate thumbnails was only applied to the collection details route. The collections route was accidentally ignored. Apply the same fix for this route now.