### PR TITLE
Add custom idc breadcrumbs

### DIFF
--- a/idc_ui_module.services.yml
+++ b/idc_ui_module.services.yml
@@ -3,3 +3,8 @@ services:
     class: Drupal\idc_ui_module\Routing\RouteSubscriber
     tags:
       - { name: event_subscriber }
+  idc_ui_module.breadcrumb:
+    class: Drupal\idc_ui_module\Breadcrumb\IdcBreadcrumbBuilder
+    arguments: ['@entity_type.manager', '@config.factory']
+    tags:
+      - { name: breadcrumb_builder, priority: 100 }

--- a/src/Breadcrumb/IdcBreadcrumbBuilder.php
+++ b/src/Breadcrumb/IdcBreadcrumbBuilder.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Drupal\idc_ui_module\Breadcrumb;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Provides breadcrumbs for nodes using a configured entity reference field.
+ */
+class IdcBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+  use StringTranslationTrait;
+
+  /**
+   * Storage to load nodes.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $nodeStorage;
+
+  /**
+   * Constructs a breadcrumb builder.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_manager
+   *   Storage to load nodes.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The configuration factory.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_manager, ConfigFactoryInterface $config_factory) {
+    $this->nodeStorage = $entity_manager->getStorage('node');
+    $this->config = \Drupal::service('config.factory')->getEditable('idc_ui_module.breadcrumbs');
+
+    $this->config->set('maxDepth', -1);
+    $this->config->set('includeSelf', false);
+    $this->config->set('referenceField', 'field_member_of');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $attributes) {
+    // Using getRawParameters for consistency (always gives a
+    // node ID string) because getParameters sometimes returns
+    // a node ID string and sometimes returns a node object.
+    $nid = $attributes->getRawParameters()->get('node');
+
+    if (\Drupal::routeMatch()->getRouteName() == 'idc-ui-module.collections') {
+      return true;
+    }
+
+    if (!empty($nid)) {
+      $node = $this->nodeStorage->load($nid);
+      return (!empty($node) && $node->hasField($this->config->get('referenceField')));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+
+    $nid = $route_match->getRawParameters()->get('node');
+    $node = $this->nodeStorage->load($nid);
+    $breadcrumb = new Breadcrumb();
+    $breadcrumb->addLink(Link::createFromRoute($this->t('Home'), '<front>'));
+    $breadcrumb->addLink(Link::createFromRoute($this->t('All collections'), 'idc-ui-module.collections'));
+
+    $chain = [];
+
+    if (!empty($nid)) {
+      $this->walkMembership($node, $chain);
+    }
+
+    if (!$this->config->get('includeSelf')) {
+      array_pop($chain);
+    }
+
+    $breadcrumb->addCacheableDependency($node);
+
+    // Add membership chain to the breadcrumb.
+    foreach ($chain as $chainlink) {
+      $breadcrumb->addCacheableDependency($chainlink);
+      $breadcrumb->addLink($chainlink->toLink());
+    }
+    $breadcrumb->addCacheContexts(['route']);
+    return $breadcrumb;
+  }
+
+  /**
+   * Follows chain of field_member_of links.
+   *
+   * We pass crumbs by reference to enable checking for looped chains.
+   */
+  protected function walkMembership(EntityInterface $entity, &$crumbs) {
+    // Avoid infinate loops, return if we've seen this before.
+    foreach ($crumbs as $crumb) {
+      if ($crumb->uuid == $entity->uuid) {
+        return;
+      }
+    }
+
+    // Add this item onto the pile.
+    array_unshift($crumbs, $entity);
+
+    if ($this->config->get('maxDepth') > 0 && count($crumbs) >= $this->config->get('maxDepth')) {
+      return;
+    }
+
+    // Find the next in the chain, if there are any.
+    if ($entity->hasField($this->config->get('referenceField')) &&
+      !$entity->get($this->config->get('referenceField'))->isEmpty() &&
+      $entity->get($this->config->get('referenceField'))->entity instanceof EntityInterface) {
+      $this->walkMembership($entity->get($this->config->get('referenceField'))->entity, $crumbs);
+    }
+  }
+}


### PR DESCRIPTION
Addresses: https://github.com/jhu-idc/iDC-general/issues/462

Adds `All Collections` to the breadcrumbs in the relevant places. Takes the islandora breadcrumb module breadcrumb builder, but removes some of the configuration since this won't be consumed by others.

<img width="1752" alt="Screen Shot 2022-02-22 at 10 42 52 AM" src="https://user-images.githubusercontent.com/6305935/155167152-ee5bdb08-44f7-48b0-96da-422e38e6ffca.png">
<img width="1752" alt="Screen Shot 2022-02-22 at 10 42 40 AM" src="https://user-images.githubusercontent.com/6305935/155167162-f5b2fc5f-a328-476a-a122-df8d6dea8d9c.png">

