### PR TITLE
Pre lags 129

### DIFF
--- a/src/Plugin/search_api/processor/SolrYears.php
+++ b/src/Plugin/search_api/processor/SolrYears.php
@@ -35,6 +35,7 @@ class SolrYears extends ProcessorPluginBase {
         'label' => $this->t('Solr Years'),
         'description' => $this->t('The year values for each item (Sort date, Pub dates, Created dates).'),
         'type' => 'string',
+        'is_list' => TRUE,
         'processor_id' => $this->getPluginId(),
       ];
       $properties['solr_years'] = new ProcessorProperty($definition);
@@ -64,10 +65,10 @@ class SolrYears extends ProcessorPluginBase {
         // Pick the lower of the possible values from pub or created dates.
         $date = FALSE;
         if ($node->hasField('field_date_published') && !$node->field_date_published->isEmpty()) {
-          $dates[] = array_merge($dates, $this->_getDatesFrom($node, 'field_date_published'));
+          $dates = $this->_getDatesFrom($node, 'field_date_published', $dates);
         }
         if ($node->hasField('field_date_created') && !$node->field_date_created->isEmpty()) {
-          $dates[] = array_merge($dates, $this->_getDatesFrom($node, 'field_date_created'));
+          $dates = $this->_getDatesFrom($node, 'field_date_created', $dates);
         }
       }
       if (count($dates) > 0) {
@@ -83,8 +84,7 @@ class SolrYears extends ProcessorPluginBase {
     }
   }
 
-  function _getDatesFrom($node, $fieldname) {
-    $dates = [];
+  function _getDatesFrom($node, $fieldname, array $dates) {
     foreach ($node->get("$fieldname") as $node_field_item) {
       $this_date = $node_field_item->value;
       $date = '';

--- a/src/Plugin/search_api/processor/SortDate.php
+++ b/src/Plugin/search_api/processor/SortDate.php
@@ -34,7 +34,7 @@ class SortDate extends ProcessorPluginBase {
       $definition = [
         'label' => $this->t('Sort Date'),
         'description' => $this->t('The sort date for each item.'),
-        'type' => 'integer',
+        'type' => 'date',
         'processor_id' => $this->getPluginId(),
       ];
       $properties['sort_date'] = new ProcessorProperty($definition);
@@ -108,7 +108,7 @@ class SortDate extends ProcessorPluginBase {
         $dates[$date] = $date;
       }
     }
-    $min_date = min(array_values($dates));
+    $min_date = strtotime(min(array_values($dates)));
     return $min_date;
   }
 

--- a/src/Plugin/search_api/processor/SortDate.php
+++ b/src/Plugin/search_api/processor/SortDate.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Drupal\idc_ui_module\Plugin\search_api\processor;
+
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+use Drupal\controlled_access_terms\EDTFUtils;
+
+/**
+ * Adds the item's single sort year value to the indexed data.
+ *
+ * @SearchApiProcessor(
+ *   id = "sort_date",
+ *   label = @Translation("Sort Date"),
+ *   description = @Translation("Derived from item's 'Sort date', 'Pub dates', or 'Creation dates' to the indexed data."),
+ *   stages = {
+ *     "add_properties" = 0,
+ *   },
+ *   locked = true,
+ *   hidden = true,
+ * )
+ */
+class SortDate extends ProcessorPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+    $properties = [];
+
+    if (!$datasource) {
+      $definition = [
+        'label' => $this->t('Sort Date'),
+        'description' => $this->t('The sort date for each item.'),
+        'type' => 'integer',
+        'processor_id' => $this->getPluginId(),
+      ];
+      $properties['sort_date'] = new ProcessorProperty($definition);
+    }
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item) {
+    $node = $item->getOriginalObject()->getValue();
+
+    /*
+     This logic needs to save only ONE year value -- which
+     should be:
+    
+     field_sort_date
+        If this has a value, use this and we are done.
+    
+     field_date_published
+        If any values, use the earliest one - we are done.
+
+     field_date_created
+        else, use earliest value from this.
+    */
+    if ($node) {
+      if ($node->hasField('field_sort_date') && !$node->field_sort_date->isEmpty()) {
+        $date = $node->field_sort_date->value;
+        $this->logger('got field_sort_date, date = ' . $date);
+      }
+      elseif ($node->hasField('field_date_published') && !$node->field_date_published->isEmpty()) {
+        $date = $this->_getEarliestDateFrom($node, 'field_date_published');
+        $this->logger('got field_date_published, date = ' . $date);
+      }
+      elseif ($node->hasField('field_date_created') && !$node->field_date_created->isEmpty()) {
+        $date = $this->_getEarliestDateFrom($node, 'field_date_created');
+        $this->logger('got field_date_created, date = ' . $date);
+      }
+      else {
+        $date = FALSE;
+      }
+      if ($date) {
+        $this->logger('ok a');
+        $fields = $item->getFields(FALSE);
+        $fields = $this->getFieldsHelper()
+          ->filterForPropertyPath($fields, NULL, 'sort_date');
+        $this->logger('ok b');
+        foreach ($fields as $field) {
+          $this->logger('a field : date = ' . $date);
+        //  $this->logger('field keys : ' . print_r($field, true));
+          $field->addValue($date);
+        }
+      }
+
+    }
+  }
+
+  function logger($string) {
+    \Drupal::logger('idc_ui_module')->info($string);
+    // echo $string . "\n";
+  }
+
+  function _getEarliestDateFrom($node, $fieldname) {
+    $this_date = $node->$fieldname->value;
+    $date = '';
+    if ($this_date != "nan") {
+      $this->logger('_getEarliestDateFrom $this_date = ' . $this_date);
+      // Special handling for YYYY/YYYY
+      if (strstr($this_date, "/") && (strlen($this_date) == 9) && (substr($this_date, 4,1) == "/")) {
+        $parts = explode("/", $this_date, 2);
+        if (count($parts) == 2 && is_numeric(0 + $parts[0]) && is_numeric(0 + $parts[1])) {
+          $lower_val = ($parts[0] < $parts[1]) ? $parts[0] : $parts[1];
+          return $lower_val;
+        }
+      }
+      $iso = EDTFUtils::iso8601Value($this_date);
+      $iso_one = explode("T", $iso)[0];
+      $components = explode('-', $iso_one);
+      $date = array_shift($components);
+    }
+    return $date;
+  }
+
+}


### PR DESCRIPTION
This minor feature branch includes the two processors `Sort Date` and `Solr Years` which are needed by `idc-isle-dc`'s configurations. These fields are both used in the backend and will have values for the nodes indexed in solr (when `idc-isle-dc`'s search_api.index.default_solr_index.yml is imported).

This is for https://jhulibraries.atlassian.net/browse/LAGS-185 and https://jhulibraries.atlassian.net/browse/LAGS-129